### PR TITLE
Fixed precedence problem

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1619,7 +1619,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$nbt->playerGameType = new IntTag("playerGameType", $this->gamemode);
 		}
 
-		$this->allowFlight = (bool) $this->gamemode & 0x01;
+		$this->allowFlight = (bool) ($this->gamemode & 0x01);
 
 		if(($level = $this->server->getLevelByName($nbt["Level"])) === null){
 			$this->setLevel($this->server->getDefaultLevel());


### PR DESCRIPTION
as mentioned in https://github.com/iTXTech/PocketMine-MP/commit/4cb76f369a40c7ec169310da1ee32876072ffd37#commitcomment-19068812

Test case:

```
$ php -r 'var_dump((bool) 1 & 1);'
int(1)

$ php -r 'var_dump((bool) 0 & 1);'
int(0)
```